### PR TITLE
Log message and code for unknown errors

### DIFF
--- a/dynamof/core/exceptions.py
+++ b/dynamof/core/exceptions.py
@@ -47,8 +47,9 @@ class BadGatewayException(DynamofException):
         return message == 'Bad Gateway'
 
 class UnknownDatabaseException(DynamofException):
-    def __init__(self):
-        message = "An unkonwn exception occured when executing request to dynamo"
+    def __init__(self, unknown_boto_client_err):
+        message, code = parse(unknown_boto_client_err)
+        message = f'An unkonwn exception occured when executing request to dynamo: {message} - {code}'
         super().__init__(message)
 
 def factory(boto_client_err):
@@ -60,7 +61,7 @@ def factory(boto_client_err):
         return ConditionNotMetException()
     if PreexistingTableException.matches(boto_client_err):
         return PreexistingTableException()
-    return UnknownDatabaseException()
+    return UnknownDatabaseException(boto_client_err)
 
 def parse(exc):
     """Takes in an exception and returns the boto

--- a/test/unit/core/exceptions_test.py
+++ b/test/unit/core/exceptions_test.py
@@ -57,3 +57,17 @@ def test_factory():
 
     exc = factory(None)
     assert isinstance(exc, UnknownDatabaseException)
+
+def test_unknown_exc_logs_message_and_code():
+    mock_err = MagicMock()
+    mock_err.response = {
+        'Error': {
+            'Code': 'XX_CODE_XX',
+            'Message': 'XX_MESSAGE_XX'
+        }
+    }
+
+    exc = factory(mock_err)
+
+    assert 'XX_CODE_XX' in exc.message
+    assert 'XX_MESSAGE_XX' in exc.message


### PR DESCRIPTION
When catching errors we now add the message and code from the boto3 error (if it contained one) to the message for the unknown exc we will bubble up.